### PR TITLE
Use system attr instead of app attr

### DIFF
--- a/matisse/src/main/res/layout/activity_matisse.xml
+++ b/matisse/src/main/res/layout/activity_matisse.xml
@@ -25,7 +25,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?colorPrimary"
+        android:background="?android:attr/colorPrimary"
         android:elevation="4dp"
         android:theme="?toolbar"
         tools:targetApi="lollipop">
@@ -33,9 +33,9 @@
         <TextView
             android:id="@+id/selected_album"
             android:layout_width="wrap_content"
-            android:layout_height="?actionBarSize"
+            android:layout_height="?android:attr/actionBarSize"
             android:drawableRight="@drawable/ic_arrow_drop_down_white_24dp"
-            android:foreground="?selectableItemBackground"
+            android:foreground="?android:attr/selectableItemBackground"
             android:gravity="center"
             android:textColor="?attr/album.element.color"
             android:textSize="20sp"/>
@@ -54,7 +54,7 @@
             android:id="@+id/button_preview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:foreground="?selectableItemBackground"
+            android:foreground="?android:attr/selectableItemBackground"
             android:padding="16dp"
             android:layout_gravity="start"
             android:text="@string/button_preview"
@@ -66,7 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:foreground="?selectableItemBackground"
+            android:foreground="?android:attr/selectableItemBackground"
             android:padding="16dp"
             android:textColor="?attr/bottomToolbar.apply.textColor"
             android:textSize="16sp"/>

--- a/matisse/src/main/res/layout/activity_media_preview.xml
+++ b/matisse/src/main/res/layout/activity_media_preview.xml
@@ -38,7 +38,7 @@
             android:id="@+id/button_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:foreground="?selectableItemBackground"
+            android:foreground="?android:attr/selectableItemBackground"
             android:padding="16dp"
             android:layout_gravity="start"
             android:text="@string/button_back"
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:foreground="?selectableItemBackground"
+            android:foreground="?android:attr/selectableItemBackground"
             android:padding="16dp"
             android:textColor="?attr/preview.bottomToolbar.apply.textColor"
             android:textSize="16sp"/>

--- a/matisse/src/main/res/layout/media_grid_item.xml
+++ b/matisse/src/main/res/layout/media_grid_item.xml
@@ -18,4 +18,4 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:foreground="?selectableItemBackground"/>
+    android:foreground="?android:attr/selectableItemBackground"/>

--- a/matisse/src/main/res/layout/photo_capture_item.xml
+++ b/matisse/src/main/res/layout/photo_capture_item.xml
@@ -19,7 +19,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?item.placeholder"
-    android:foreground="?selectableItemBackground">
+    android:foreground="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/hint"


### PR DESCRIPTION
```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.mercariapp.mercari/com.zhihu.matisse.ui.MatisseActivity}: android.view.InflateException: Binary XML file line #33: Binary XML file line #33: Error inflating class TextView
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2955)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3030)
       at android.app.ActivityThread.-wrap11(Unknown Source)
...
Caused by java.lang.UnsupportedOperationException: Failed to resolve attribute at index 5: TypedValue{t=0x2/d=0x7f030027 a=-1}
       at android.content.res.TypedArray.getColorStateList(TypedArray.java:538)
       at android.widget.TextView.(TextView.java:1550)
       at android.widget.TextView.(TextView.java:1129)
```


Crashes often happen because TextView is possibly referencing style that does not exit. Use `?android:attr/` to use the default value for styling


https://developer.android.com/guide/topics/resources/accessing-resources.html#ReferencesToThemeAttributes