### PR TITLE
Support plurals by default

### DIFF
--- a/matisse/src/main/res/values/strings.xml
+++ b/matisse/src/main/res/values/strings.xml
@@ -26,7 +26,12 @@
     <string name="button_ok">OK</string>
 
     <string name="error_over_count_default">You have reached max selectable</string>
-    <string name="error_over_count">You can only select up to %1$d media files</string>
+    <plurals name="error_over_count">
+        <item quantity="one">You can only select up to %1$d media file</item>
+        <item quantity="few">You can only select up to %1$d media files</item>
+        <item quantity="many">You can only select up to %1$d media files</item>
+        <item quantity="other">You can only select up to %1$d media files</item>
+    </plurals>
     <string name="error_under_quality">Under quality</string>
     <string name="error_over_quality">Over quality</string>
     <string name="error_file_type">Unsupported file type</string>


### PR DESCRIPTION
# Issue
- Error message shows up when opened project with AS 3.2

<img width="1712" alt="screen shot 2018-06-04 at 2 23 05 pm" src="https://user-images.githubusercontent.com/6277118/40943311-6b682a28-6805-11e8-93f1-9738d1c98cc5.png">

- release build fails with the message below when running `bundleRelease`

```
Warning: com.zhihu.matisse.internal.model.SelectedItemCollection: can't find referenced class com.zhihu.matisse.R$plurals
Warning: com.zhihu.matisse.internal.model.SelectedItemCollection: can't find referenced class com.zhihu.matisse.R$plurals
```

# Cause

default resource does not have `plurals`

# Fix

- Add plurals for `res/values/strings.xml`